### PR TITLE
Adding back file based latching

### DIFF
--- a/tools/rosbag/README.md
+++ b/tools/rosbag/README.md
@@ -17,7 +17,8 @@ rosbag record --file-name record.yaml
 # topic_name: freq(double)
 # topic_name: -1 (it will be recorded at publish freq)
 #           : 0 (it will not be recorded)
-#           : -2 (for latched topics, to keep latched topics in every bag split)
+#           : -2 (for latched/[pseudo-latched](https://github.com/rapyuta-robotics/ros_comm/pull/10#issue-463244616) topics, to keep them in every bag split)
+#               Note: --repeat-latched option only takes topic which has topic info latch=true it does not take pseudo-latched topics (described in above link)
 
 # For topic name same regular expressions cli can be used: ex. "/realsense(.*)" : 0
 # [used by default rosbag](http://wiki.ros.org/rosbag/Commandline)

--- a/tools/rosbag/README.md
+++ b/tools/rosbag/README.md
@@ -17,6 +17,7 @@ rosbag record --file-name record.yaml
 # topic_name: freq(double)
 # topic_name: -1 (it will be recorded at publish freq)
 #           : 0 (it will not be recorded)
+#           : -2 (for latched topics, to keep latched topics in every bag split)
 
 # For topic name same regular expressions cli can be used: ex. "/realsense(.*)" : 0
 # [used by default rosbag](http://wiki.ros.org/rosbag/Commandline)

--- a/tools/rosbag/src/record.cpp
+++ b/tools/rosbag/src/record.cpp
@@ -153,6 +153,10 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
         {
             opts.custom_record_freq.emplace(it->first.as<std::string>(), ros::Duration(0));
         }
+        else if (freq == -2)
+        {
+            opts.custom_record_freq.emplace(it->first.as<std::string>(), ros::Duration(-2));
+        }       
         else
         {
             opts.custom_record_freq.emplace(it->first.as<std::string>(), ros::Duration(double(1)/freq));

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -354,7 +354,6 @@ void Recorder::doQueue(const ros::MessageEvent<topic_tools::ShapeShifter const>&
             ros::M_string::const_iterator it = out.connection_header->find("latching");
             if ((it != out.connection_header->end()) && (it->second == "1"))
             {
-                ROS_INFO_STREAM(subscriber->getTopic());
                 ros::M_string::const_iterator it2 = out.connection_header->find("callerid");
                 if (it2 != out.connection_header->end())
                 {

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -354,6 +354,7 @@ void Recorder::doQueue(const ros::MessageEvent<topic_tools::ShapeShifter const>&
             ros::M_string::const_iterator it = out.connection_header->find("latching");
             if ((it != out.connection_header->end()) && (it->second == "1"))
             {
+                ROS_INFO_STREAM(subscriber->getTopic());
                 ros::M_string::const_iterator it2 = out.connection_header->find("callerid");
                 if (it2 != out.connection_header->end())
                 {
@@ -479,6 +480,13 @@ void Recorder::startWriting() {
 }
 
 void Recorder::stopWriting() {
+    for (const auto& topic : options_.custom_record_freq)
+    {
+        if (topic.second == ros::Duration(-2))
+        {
+            currently_recording_.erase(topic.first);
+        }
+    }    
     ROS_INFO("Closing '%s'.", target_filename_.c_str());
     bag_.close();
     rename(write_filename_.c_str(), target_filename_.c_str());


### PR DESCRIPTION
Since --repeat-latched can not detect pseudo-latched topics like:- 
https://github.com/ros-planning/navigation/blob/melodic-devel/costmap_2d/src/costmap_2d_publisher.cpp#L52
it uses [different method](https://docs.ros.org/api/roscpp/html/classros_1_1NodeHandle.html#ae4711ef282892176ba145d02f8f45f8d) for advertising with `latch=false`, and the rosbag can not get correct info for latching option and does not able to record costmap topic with --repeat-latch option when splits happen.