### PR TITLE
Hotfix/gn remove order based priority

### DIFF
--- a/tools/rosbag/include/rosbag/recorder.h
+++ b/tools/rosbag/include/rosbag/recorder.h
@@ -120,11 +120,6 @@ struct ROSBAG_DECL RecorderOptions
     std::unordered_map<std::string, ros::Duration> custom_record_blacklist;
 
     std::vector<std::string> topics;
-
-    inline bool isTopicInCustom(const std::string str) {
-        return (custom_record_blacklist.find(str) != custom_record_blacklist.end() ||
-               custom_record_whitelist.find(str) != custom_record_whitelist.end());
-    }
 };
 
 class ROSBAG_DECL Recorder

--- a/tools/rosbag/include/rosbag/recorder.h
+++ b/tools/rosbag/include/rosbag/recorder.h
@@ -116,9 +116,15 @@ struct ROSBAG_DECL RecorderOptions
     unsigned long long min_space;
     std::string min_space_str;
     ros::TransportHints transport_hints;
-    std::unordered_map<std::string, ros::Duration>    custom_record_freq;
+    std::unordered_map<std::string, ros::Duration> custom_record_whitelist;
+    std::unordered_map<std::string, ros::Duration> custom_record_blacklist;
 
     std::vector<std::string> topics;
+
+    inline bool isTopicInCustom(const std::string str) {
+        return (custom_record_blacklist.find(str) != custom_record_blacklist.end() ||
+               custom_record_whitelist.find(str) != custom_record_whitelist.end());
+    }
 };
 
 class ROSBAG_DECL Recorder

--- a/tools/rosbag/src/record.cpp
+++ b/tools/rosbag/src/record.cpp
@@ -137,8 +137,8 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
 
       for (YAML::const_iterator it = custom_freq_config.begin(); it!=custom_freq_config.end(); ++it)
       {
-        if (opts.custom_record_blacklist(it->first.as<std::string>()) != opts.custom_record_blacklist.end() ||
-                  opts.custom_record_whitelist(it->first.as<std::string>()) != opts.custom_record_whitelist.end()) 
+        if (opts.custom_record_blacklist.find(it->first.as<std::string>()) != opts.custom_record_blacklist.end() ||
+                  opts.custom_record_whitelist.find(it->first.as<std::string>()) != opts.custom_record_whitelist.end()) 
         {
             ROS_WARN("Duplicate topic in file, Topic name:= %s ; Topic will be recorded on the basis of first entry",
                     it->first.as<std::string>().c_str());

--- a/tools/rosbag/src/record.cpp
+++ b/tools/rosbag/src/record.cpp
@@ -137,29 +137,29 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
 
       for (YAML::const_iterator it = custom_freq_config.begin(); it!=custom_freq_config.end(); ++it)
       {
-        if (!opts.custom_record_freq.empty() && opts.custom_record_freq.find(it->first.as<std::string>())!=opts.custom_record_freq.end())
-        {
-          ROS_WARN("Duplicate topic in file, Topic name:= %s ; Topic will be recorded on the basis of first entry", it->first.as<std::string>().c_str());
-          continue;
-        }
+          if (opts.isTopicInCustom(it->first.as<std::string>())) {
+              ROS_WARN("Duplicate topic in file, Topic name:= %s ; Topic will be recorded on the basis of first entry",
+                      it->first.as<std::string>().c_str());
+              continue;
+          }
         double freq = it->second.as<double>();
         opts.topics.push_back(it->first.as<std::string>());
 
         if (freq == 0)
         {
-            opts.custom_record_freq.emplace(it->first.as<std::string>(), ros::Duration(-1));
+            opts.custom_record_blacklist.emplace(it->first.as<std::string>(), ros::Duration(-1));
         }
         else if (freq == -1)
         {
-            opts.custom_record_freq.emplace(it->first.as<std::string>(), ros::Duration(0));
+            opts.custom_record_whitelist.emplace(it->first.as<std::string>(), ros::Duration(0));
         }
         else if (freq == -2)
         {
-            opts.custom_record_freq.emplace(it->first.as<std::string>(), ros::Duration(-2));
-        }       
+            opts.custom_record_whitelist.emplace(it->first.as<std::string>(), ros::Duration(-2));
+        }
         else
         {
-            opts.custom_record_freq.emplace(it->first.as<std::string>(), ros::Duration(double(1)/freq));
+            opts.custom_record_whitelist.emplace(it->first.as<std::string>(), ros::Duration(double(1)/freq));
         }
       }
     }

--- a/tools/rosbag/src/record.cpp
+++ b/tools/rosbag/src/record.cpp
@@ -137,11 +137,13 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
 
       for (YAML::const_iterator it = custom_freq_config.begin(); it!=custom_freq_config.end(); ++it)
       {
-          if (opts.isTopicInCustom(it->first.as<std::string>())) {
-              ROS_WARN("Duplicate topic in file, Topic name:= %s ; Topic will be recorded on the basis of first entry",
-                      it->first.as<std::string>().c_str());
-              continue;
-          }
+        if (opts.custom_record_blacklist(it->first.as<std::string>()) != opts.custom_record_blacklist.end() ||
+                  opts.custom_record_whitelist(it->first.as<std::string>()) != opts.custom_record_whitelist.end()) 
+        {
+            ROS_WARN("Duplicate topic in file, Topic name:= %s ; Topic will be recorded on the basis of first entry",
+                    it->first.as<std::string>().c_str());
+            continue;
+        }
         double freq = it->second.as<double>();
         opts.topics.push_back(it->first.as<std::string>());
 

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -298,22 +298,23 @@ bool Recorder::shouldSubscribeToTopic(std::string const& topic, bool from_node) 
             });
     }
 
-    return std::find_if(std::begin(options_.topics), std::end(options_.topics),
-                   [blacklist = &options_.custom_record_blacklist, whitelist = &options_.custom_record_whitelist, topic](
-                           std::string& topic_arg) {
-                       if (topic == topic_arg) 
-                       {
-                           return true;
-                       } 
-                       else 
-                       {
-                           if (!blacklist->empty() || !whitelist->empty()) 
-                           {
-                               blacklist->emplace(topic, ros::Duration(-1));
-                           }
-                           return false;
-                       }
-                   }) != std::end(options_.topics);
+    return std::any_of(
+            std::begin(options_.topics), std::end(options_.topics),
+            [blacklist = &options_.custom_record_blacklist, whitelist = &options_.custom_record_whitelist, topic](
+                    std::string& topic_arg) {
+                if (topic == topic_arg) 
+                {
+                    return true;
+                } 
+                else 
+                {
+                    if (!blacklist->empty() || !whitelist->empty()) 
+                    {
+                        blacklist->emplace(topic, ros::Duration(-1));
+                    }
+                    return false;
+                }
+            });
 }
 
 template<class T>

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -258,18 +258,22 @@ bool Recorder::shouldSubscribeToTopic(std::string const& topic, bool from_node) 
         return false;
     }
 
-    for (const auto& it : options_.custom_record_whitelist) {
+    for (const auto& it : options_.custom_record_whitelist) 
+    {
         boost::regex e(it.first);
         boost::smatch what;
-        if (boost::regex_match(topic, what, e, boost::match_extra)) {
+        if (boost::regex_match(topic, what, e, boost::match_extra)) 
+        {
             options_.custom_record_whitelist[topic] = it.second;
             return true;
         }
     }
-    for (const auto& it : options_.custom_record_blacklist) {
+    for (const auto& it : options_.custom_record_blacklist) 
+    {
         boost::regex e(it.first);
         boost::smatch what;
-        if (boost::regex_match(topic, what, e, boost::match_extra)) {
+        if (boost::regex_match(topic, what, e, boost::match_extra)) 
+        {
             options_.custom_record_blacklist[topic] = it.second;
             return false;
         }


### PR DESCRIPTION
https://www.wrike.com/open.htm?id=552265183

When device downloads param file from io params, the file is sorted based on alphabetical order and that was causing issue to rosbag (was not recording all topic mentioned in the file).. Since rosbag highly rely on order in the file.

And a little bit clean up.