### PR TITLE
change spliter topic to service

### DIFF
--- a/tools/rosbag/README.md
+++ b/tools/rosbag/README.md
@@ -12,6 +12,13 @@ rosbag record --file-name record.yaml
 ## param 
 * --file-name: file which has topics for custom recording
 
+## services
+* Split rosbag
+    * service_name: split_bag
+    * type: std_srvs/Empty
+    * description: call the service to create a split forcefully
+
+
 ## example:- record.yaml
 ```yaml
 # topic_name: freq(double)

--- a/tools/rosbag/include/rosbag/recorder.h
+++ b/tools/rosbag/include/rosbag/recorder.h
@@ -189,7 +189,7 @@ private:
     uint64_t                      split_count_;          //!< split count
     bool                          split_requested_;
     boost::mutex                  split_mutex_;
-    boost::condition_variable_any split_condition_;  //!< conditional variable for queue
+    boost::condition_variable_any split_condition_;      //!< conditional variable for split
 
     std::queue<OutgoingQueue>     queue_queue_;          //!< queue of queues to be used by the snapshot recorders
 

--- a/tools/rosbag/include/rosbag/recorder.h
+++ b/tools/rosbag/include/rosbag/recorder.h
@@ -56,6 +56,7 @@
 #include <ros/ros.h>
 #include <ros/time.h>
 
+#include <std_srvs/Empty.h>
 #include <std_msgs/Empty.h>
 #include <std_msgs/String.h>
 #include <topic_tools/shape_shifter.h>
@@ -147,7 +148,7 @@ private:
     bool checkDisk();
 
     void snapshotTrigger(std_msgs::Empty::ConstPtr trigger);
-    void manual_split(std_msgs::Empty::ConstPtr msg);
+    bool manual_split(std_srvs::Empty::Request& req, std_srvs::Empty::Response& res);
     //    void doQueue(topic_tools::ShapeShifter::ConstPtr msg, std::string const& topic, boost::shared_ptr<ros::Subscriber> subscriber, boost::shared_ptr<int> count);
     void doQueue(const ros::MessageEvent<topic_tools::ShapeShifter const>& msg_event, std::string const& topic, boost::shared_ptr<ros::Subscriber> subscriber, boost::shared_ptr<int> count);
     void doRecord();
@@ -186,7 +187,7 @@ private:
     uint64_t                      max_queue_size_;       //!< max queue size
 
     uint64_t                      split_count_;          //!< split count
-    bool                          split_bag_;
+    bool                          split_requested_;
 
     std::queue<OutgoingQueue>     queue_queue_;          //!< queue of queues to be used by the snapshot recorders
 

--- a/tools/rosbag/include/rosbag/recorder.h
+++ b/tools/rosbag/include/rosbag/recorder.h
@@ -188,6 +188,8 @@ private:
 
     uint64_t                      split_count_;          //!< split count
     bool                          split_requested_;
+    boost::mutex                  split_mutex_;
+    boost::condition_variable_any split_condition_;  //!< conditional variable for queue
 
     std::queue<OutgoingQueue>     queue_queue_;          //!< queue of queues to be used by the snapshot recorders
 

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -465,7 +465,8 @@ void Recorder::snapshotTrigger(std_msgs::Empty::ConstPtr trigger) {
 }
 
 bool Recorder::manual_split(
-        [[maybe_unused]] std_srvs::Empty::Request& req, [[maybe_unused]] std_srvs::Empty::Response& res) {
+        [[maybe_unused]] std_srvs::Empty::Request& req, [[maybe_unused]] std_srvs::Empty::Response& res) 
+{
     boost::unique_lock<boost::mutex> lock(split_mutex_);
     split_requested_ = true;
     split();

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -122,7 +122,7 @@ Recorder::Recorder(RecorderOptions const& options) :
     exit_code_(0),
     queue_size_(0),
     split_count_(0),
-    split_bag_(false),
+    split_requested_(false),
     writing_enabled_(true)
 {
 }
@@ -198,10 +198,11 @@ int Recorder::run() {
         record_thread = boost::thread(boost::bind(&Recorder::doRecord, this));
 
     ros::Subscriber split_sub;
+    ros::ServiceServer split_service;
 
     if (options_.split)
     {
-        split_sub = nh.subscribe<std_msgs::Empty>("split_bag", 100, boost::bind(&Recorder::manual_split, this, _1));
+        split_service = nh.advertiseService("split_bag", &Recorder::manual_split, this);
     }
 
     ros::Timer check_master_timer;
@@ -463,9 +464,12 @@ void Recorder::snapshotTrigger(std_msgs::Empty::ConstPtr trigger) {
     queue_condition_.notify_all();
 }
 
-void Recorder::manual_split(std_msgs::Empty::ConstPtr msg) {
-    (void)msg;
-    split_bag_ = true;
+bool Recorder::manual_split(
+        [[maybe_unused]] std_srvs::Empty::Request& req, [[maybe_unused]] std_srvs::Empty::Response& res) {
+    split_requested_ = true;
+    split();
+    split_requested_ = false;
+    return true;
 }
 
 void Recorder::startWriting() {
@@ -642,15 +646,10 @@ void Recorder::doRecord() {
 
         if (checkDuration(out.time))
             break;
-        
-        if (split_bag_) {
-            split();
-            split_bag_ = false;
-        }
 
         try
         {
-            if (scheduledCheckDisk() && checkLogging())
+            if (scheduledCheckDisk() && checkLogging() && !split_requested_)
                 bag_.write(out.topic, out.time, *out.msg, out.connection_header);
         }
         catch (const rosbag::BagException& ex)

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -653,7 +653,6 @@ void Recorder::doRecord() {
 
         boost::unique_lock<boost::mutex> split_lock(split_mutex_);
         split_condition_.wait(split_lock, [this]() { return !split_requested_; });
-        split_lock.unlock();
         try
         {
             if (scheduledCheckDisk() && checkLogging())
@@ -665,6 +664,7 @@ void Recorder::doRecord() {
             exit_code_ = 1;
             break;
         }
+        split_lock.unlock();
     }
 
     stopWriting();


### PR DESCRIPTION
The archiver has to make sure that the split has been created before starting the logging, so now it will wait for a response from the service call.