### PR TITLE
fix rosbag split

### DIFF
--- a/tools/rosbag/include/rosbag/recorder.h
+++ b/tools/rosbag/include/rosbag/recorder.h
@@ -156,6 +156,7 @@ private:
     void split(ros::Duration start_increment = ros::Duration(0));
     bool checkSize();
     bool checkDuration(const ros::Time&);
+    void checkManualTrigger(const ros::Time&);
     void doRecordSnapshotter();
     void doCheckMaster(ros::TimerEvent const& e, ros::NodeHandle& node_handle);
 
@@ -187,7 +188,7 @@ private:
     uint64_t                      max_queue_size_;       //!< max queue size
 
     uint64_t                      split_count_;          //!< split count
-    bool                          split_requested_;
+    std::atomic_bool              split_requested_;
     boost::mutex                  split_mutex_;
     boost::condition_variable_any split_condition_;      //!< conditional variable for split
 


### PR DESCRIPTION
Fixes following issues:
1. prevents double free corruption when manual split and automated split try to split at same time
2. The thread being waited on is the callback thread (one of the 10 async spinner threads) and not the main thread
3. The start time increment is respected when manual split is triggered 