### PR TITLE
fixes rosbag recording when both size and duration are mentioned as splitting criteria 

### DIFF
--- a/tools/rosbag/include/rosbag/recorder.h
+++ b/tools/rosbag/include/rosbag/recorder.h
@@ -154,7 +154,7 @@ private:
     void doRecord();
     void checkNumSplits();
     void split(ros::Duration start_increment = ros::Duration(0));
-    bool checkSize();
+    bool checkSize(const ros::Time&);
     bool checkDuration(const ros::Time&);
     void checkManualTrigger(const ros::Time&);
     void doRecordSnapshotter();

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -595,7 +595,7 @@ void Recorder::split(ros::Duration start_increment)
     }
 }
 
-bool Recorder::checkSize()
+bool Recorder::checkSize(const ros::Time& t)
 {
     if (options_.max_size > 0)
     {
@@ -603,7 +603,7 @@ bool Recorder::checkSize()
         {
             if (options_.split)
             {
-                split();
+                split(t - start_time_));
             } else {
                 ros::shutdown();
                 return true;
@@ -697,7 +697,7 @@ void Recorder::doRecord() {
         
         lock.release()->unlock();
         
-        if (checkSize())
+        if (checkSize(out.time))
             break;
 
         if (checkDuration(out.time))


### PR DESCRIPTION
While working on the feature to support splitting rosbags by duration on rapyuta io., we were testing one scenario where we gave both split by size and split by duration as mentioned below
`rosbag record --all --split --size 10 --split --duration 1m --max-splits 20`

The behavior seems to be weird, initially, bag 0 (the first bag) reaches 10 MB and it splits and creates bag 1 but bag 1 splits at 850 kb (before reaching 1 minute) but the max duration tracker doesn't seem to be resetting after splitting at bag 0 and still considers the start time of bag 0 for bag 1.
Refer to the screenshot here
![image (1)](https://user-images.githubusercontent.com/95404550/207030607-2574cda9-2630-4e4a-b3ee-0569644260f9.png)

This PR fixes this issue by updating the `start_time_` when split by size