### PR TITLE
Change split service to specify filename

### DIFF
--- a/tools/rosbag/CMakeLists.txt
+++ b/tools/rosbag/CMakeLists.txt
@@ -5,12 +5,16 @@ if(NOT WIN32)
   set_directory_properties(PROPERTIES COMPILE_OPTIONS "-Wall;-Wextra")
 endif()
 
-find_package(catkin REQUIRED COMPONENTS rosbag_storage rosconsole roscpp std_srvs topic_tools xmlrpcpp)
+find_package(catkin REQUIRED COMPONENTS rosbag_storage rosconsole roscpp std_srvs topic_tools xmlrpcpp message_generation)
 find_package(Boost REQUIRED COMPONENTS date_time filesystem program_options regex thread)
 find_package(BZip2 REQUIRED)
 find_package(yaml-cpp REQUIRED)
 
 catkin_python_setup()
+
+add_service_files(FILES SplitBag.srv)
+
+generate_messages()
 
 # Support large bags (>2GB) on 32-bit systems
 add_definitions(-D_FILE_OFFSET_BITS=64)
@@ -32,6 +36,8 @@ add_library(rosbag
 target_link_libraries(rosbag ${catkin_LIBRARIES} ${Boost_LIBRARIES}
   ${BZIP2_LIBRARIES} ${YAML_CPP_LIBRARIES}
 )
+
+add_dependencies(rosbag ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 add_executable(record src/record.cpp)
 target_link_libraries(record rosbag)

--- a/tools/rosbag/include/rosbag/recorder.h
+++ b/tools/rosbag/include/rosbag/recorder.h
@@ -56,7 +56,6 @@
 #include <ros/ros.h>
 #include <ros/time.h>
 
-#include <std_srvs/Empty.h>
 #include <std_msgs/Empty.h>
 #include <std_msgs/String.h>
 #include <topic_tools/shape_shifter.h>
@@ -64,6 +63,7 @@
 #include "rosbag/bag.h"
 #include "rosbag/stream.h"
 #include "rosbag/macros.h"
+#include "rosbag/SplitBag.h"
 
 namespace rosbag {
 
@@ -148,7 +148,7 @@ private:
     bool checkDisk();
 
     void snapshotTrigger(std_msgs::Empty::ConstPtr trigger);
-    bool manual_split(std_srvs::Empty::Request& req, std_srvs::Empty::Response& res);
+    bool manual_split(rosbag::SplitBag::Request& req, rosbag::SplitBag::Response& res);
     //    void doQueue(topic_tools::ShapeShifter::ConstPtr msg, std::string const& topic, boost::shared_ptr<ros::Subscriber> subscriber, boost::shared_ptr<int> count);
     void doQueue(const ros::MessageEvent<topic_tools::ShapeShifter const>& msg_event, std::string const& topic, boost::shared_ptr<ros::Subscriber> subscriber, boost::shared_ptr<int> count);
     void doRecord();
@@ -189,6 +189,7 @@ private:
 
     uint64_t                      split_count_;          //!< split count
     std::atomic_bool              split_requested_;
+    std::string                   split_filename_;       //!< name for the split file
     boost::mutex                  split_mutex_;
     boost::condition_variable_any split_condition_;      //!< conditional variable for split
 

--- a/tools/rosbag/package.xml
+++ b/tools/rosbag/package.xml
@@ -41,6 +41,7 @@
   <build_depend condition="$ROS_PYTHON_VERSION == 3">python3-pil</build_depend>
   <build_depend>roscpp_serialization</build_depend>
   <build_depend>topic_tools</build_depend>
+  <build_depend>message_generation</build_depend>
 
   <exec_depend>genmsg</exec_depend>
   <exec_depend>genpy</exec_depend>
@@ -53,6 +54,7 @@
   <exec_depend>roslib</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>topic_tools</exec_depend>
+  <exec_depend>message_runtime</exec_depend>
 
   <export>
     <rosdoc config="${prefix}/rosdoc.yaml"/>

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -565,8 +565,9 @@ void Recorder::stopWriting() {
         boost::unique_lock<boost::mutex> lock(split_mutex_);
         if (!split_filename_.empty())
         {
-            target_filename = split_filename_;
-            split_filename_.clear();
+            const auto idx = target_filename.rfind('/');
+            target_filename = idx != std::string::npos ? target_filename.substr(0, idx + 1) : "";
+            target_filename += split_filename_;
         }
     }
     ROS_INFO("Closing '%s'.", target_filename.c_str());
@@ -576,6 +577,15 @@ void Recorder::stopWriting() {
 
 void Recorder::checkNumSplits()
 {
+    {
+        // don't count specific split filenames towards max limit
+        boost::unique_lock<boost::mutex> lock(split_mutex_);
+        if (!split_filename_.empty())
+        {
+            return;
+        }
+    }
+    
     if(options_.max_splits>0)
     {
         current_files_.push_back(target_filename_);
@@ -601,6 +611,7 @@ void Recorder::split(ros::Duration start_increment)
     {
         boost::unique_lock<boost::mutex> lock(split_mutex_);
         split_requested_ = false;
+        split_filename_.clear();
         split_condition_.notify_all();
     }
 }

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -507,10 +507,11 @@ void Recorder::snapshotTrigger(std_msgs::Empty::ConstPtr trigger) {
 }
 
 bool Recorder::manual_split(
-        [[maybe_unused]] std_srvs::Empty::Request& req, [[maybe_unused]] std_srvs::Empty::Response& res) 
+        rosbag::SplitBag::Request& req, [[maybe_unused]] rosbag::SplitBag::Response& res)
 {
     boost::unique_lock<boost::mutex> lock(split_mutex_);
     split_requested_ = true;
+    split_filename_ = req.filename;
     // this callback thread waits until a bag split is initiated
     split_condition_.wait(lock, [this]() { return !split_requested_; });
     return true;
@@ -558,10 +559,19 @@ void Recorder::stopWriting() {
         {
             currently_recording_.erase(topic.first);
         }
-    }    
-    ROS_INFO("Closing '%s'.", target_filename_.c_str());
+    }
+    std::string target_filename = target_filename_;
+    {
+        boost::unique_lock<boost::mutex> lock(split_mutex_);
+        if (!split_filename_.empty())
+        {
+            target_filename = split_filename_;
+            split_filename_.clear();
+        }
+    }
+    ROS_INFO("Closing '%s'.", target_filename.c_str());
     bag_.close();
-    rename(write_filename_.c_str(), target_filename_.c_str());
+    rename(write_filename_.c_str(), target_filename.c_str());
 }
 
 void Recorder::checkNumSplits()

--- a/tools/rosbag/srv/SplitBag.srv
+++ b/tools/rosbag/srv/SplitBag.srv
@@ -1,0 +1,2 @@
+string filename
+---


### PR DESCRIPTION
## Description

[Wrike Task](https://www.wrike.com/open.htm?id=1285700721)
Replace `std_srvs/Empty` with a new service which receives a string with the filename of the split file.
If the filename is empty we keep old behavior.

## Testing

```bash 
> rosservice call /split_bag "filename: 'hello_world.bag'" 
```