### PR TITLE
ci: use ubuntu-latest-16-cores runner for faster builds

### DIFF
--- a/.github/workflows/build-noetic.yaml
+++ b/.github/workflows/build-noetic.yaml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary
Upgrades the build-noetic workflow runner from `ubuntu-latest` to `ubuntu-latest-16-cores` for faster compilation, especially for the arm64 QEMU-emulated builds.
## Changes
- `build-noetic.yaml`: `runs-on: ubuntu-latest` → `runs-on: ubuntu-latest-16-cores`
## Notes
- The 16-core runner is now available at the org level for all repos
- The `patch-image.yaml` workflow is left on `ubuntu-latest` since it only swaps a `.so` file (no compilation needed)